### PR TITLE
use std::pin::PinMut to work with Rust version 1.30.0-nightly

### DIFF
--- a/src/secret/mod.rs
+++ b/src/secret/mod.rs
@@ -3,7 +3,7 @@
 use std::time::{Duration, Instant};
 use std::future::{Future, FutureObj};
 use std::marker::Unpin;
-use std::mem::PinMut;
+use std::pin::PinMut;
 use std::sync::{Arc, Mutex, Condvar};
 use std::task::{
     self,

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -2,7 +2,7 @@
 
 use std::future::Future;
 use std::marker::Unpin;
-use std::mem::PinMut;
+use std::pin::PinMut;
 use std::sync::{Arc, Mutex};
 use std::task::{self, Poll, Waker};
 use std::thread; // You'll want to use `spawn` and `sleep`.


### PR DESCRIPTION
I just wanted to submit a change from `std::mem` to `std::pin` so that this tutorial works with the newest changes to this module. The change can be seen in the documentation below. Thanks. :)
https://doc.rust-lang.org/nightly/std/pin/struct.PinMut.html